### PR TITLE
feat: Open Discord link in Discord client if installed

### DIFF
--- a/src/TeardownMultiplayerLauncher/Core/CoreApi.cs
+++ b/src/TeardownMultiplayerLauncher/Core/CoreApi.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -109,13 +110,19 @@ namespace TeardownMultiplayerLauncher.Core
 
         public void OpenDiscordServer()
         {
-            Process.Start(
-                new ProcessStartInfo(_state.DiscordUrl)
-                {
-                    UseShellExecute = true,
-                    Verb = "open",
-                }
-            );
+            var appData = Environment.ExpandEnvironmentVariables("%localappdata%");
+            if (Directory.Exists(appData + "\\Discord") || Directory.Exists(appData + "\\DiscordCanary") || Directory.Exists(appData + "\\DiscordPTB")) {
+                System.Diagnostics.Process.Start("explorer.exe", "discord:discord.gg/h8eSabqdA6");
+            }
+            else {
+                Process.Start(
+                    new ProcessStartInfo("https://discord.gg/h8eSabqdA6")
+                    {
+                        UseShellExecute = true,
+                        Verb = "open",
+                    }
+                );
+            } 
         }
 
         public void OpenLauncherReleasePage()

--- a/src/TeardownMultiplayerLauncher/Core/CoreApi.cs
+++ b/src/TeardownMultiplayerLauncher/Core/CoreApi.cs
@@ -110,19 +110,7 @@ namespace TeardownMultiplayerLauncher.Core
 
         public void OpenDiscordServer()
         {
-            var appData = Environment.ExpandEnvironmentVariables("%localappdata%");
-            if (Directory.Exists(appData + "\\Discord") || Directory.Exists(appData + "\\DiscordCanary") || Directory.Exists(appData + "\\DiscordPTB")) {
-                System.Diagnostics.Process.Start("explorer.exe", "discord:discord.gg/h8eSabqdA6");
-            }
-            else {
-                Process.Start(
-                    new ProcessStartInfo("https://discord.gg/h8eSabqdA6")
-                    {
-                        UseShellExecute = true,
-                        Verb = "open",
-                    }
-                );
-            } 
+            DiscordUtility.OpenDiscordServer(_state.DiscordUrl);
         }
 
         public void OpenLauncherReleasePage()

--- a/src/TeardownMultiplayerLauncher/Core/Utilities/DiscordUtility.cs
+++ b/src/TeardownMultiplayerLauncher/Core/Utilities/DiscordUtility.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TeardownMultiplayerLauncher.Core.Utilities;
+internal static class DiscordUtility
+{
+    private static readonly HashSet<string> DiscordClientDirectories = new HashSet<string> { "Discord", "DiscordCanary", "DiscordPTB" };
+
+    /// <summary>
+    /// Opens the specified Discord server in a web browser or in a Discord client if detected on the system.
+    /// </summary>
+    /// <param name="serverUrl">Discord server URL</param>
+    public static void OpenDiscordServer(string serverUrl)
+    {
+        Process.Start(
+            new ProcessStartInfo(IsDiscordClientInstalled() ? $"discord:{serverUrl}" : serverUrl)
+            {
+                UseShellExecute = true,
+                Verb = "open",
+            }
+        );
+    }
+
+    private static bool IsDiscordClientInstalled()
+    {
+        var appData = Environment.ExpandEnvironmentVariables("%localappdata%");
+        return DiscordClientDirectories.Any(discordDirectory =>
+        {
+            var directory = Path.Combine(appData, discordDirectory);
+            return
+                Directory.Exists(directory) &&
+                !File.Exists(Path.Combine(directory, ".dead")); // If Discord is uninstalled, it leaves a .dead file in the directory to indicate this.
+        });
+    }
+}

--- a/src/TeardownMultiplayerLauncher/TeardownMultiplayerLauncher.csproj
+++ b/src/TeardownMultiplayerLauncher/TeardownMultiplayerLauncher.csproj
@@ -10,7 +10,7 @@
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
     <FileVersion></FileVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <AssemblyVersion>0.4.0</AssemblyVersion>
+    <AssemblyVersion>0.5.0</AssemblyVersion>
     <Title>Teardown Multiplayer Launcher</Title>
     <Company>TDMP Team</Company>
     <Product>Teardown Multiplayer Launcher</Product>


### PR DESCRIPTION
This change, introduced in https://github.com/TDMP-Team/TDMP-Launcher/pull/27 by @MrEnder0 opens the Discord link in the user's installed Discord client if detected, otherwise opens it in the default web browser.